### PR TITLE
New API to exclude potentially inefficient allprop

### DIFF
--- a/src/de/aflx/sardine/DavResource.java
+++ b/src/de/aflx/sardine/DavResource.java
@@ -215,13 +215,24 @@ public class DavResource
 	 */
 	private long getContentLength(Response response)
 	{
-//		Propstat list = response.getPropstat();
-//		if(list.equals("") || null == list) {
-//			return null;
-//		}
-//		Getcontentlength gcl = list.getProp().ge;
+
+		Propstat list = response.getPropstat();
+		if(list.equals("") || null == list) {
+			return DEFAULT_CONTENT_LENGTH;
+		}
 		
-		return -1;
+		String gcl = list.getProp().getGetcontentlength();
+        if ((gcl != null) && (!gcl.isEmpty()))
+        {
+            try
+            {
+                return Long.parseLong(gcl);
+            } catch (NumberFormatException e)
+            {
+                log.warn(String.format("Failed to parse content length %s", gcl));
+            }
+        }
+		return DEFAULT_CONTENT_LENGTH;
 		/*List<Propstat> list = response.getPropstat();
 		if (list.isEmpty()) {
 			return DEFAULT_CONTENT_LENGTH;

--- a/src/de/aflx/sardine/Sardine.java
+++ b/src/de/aflx/sardine/Sardine.java
@@ -62,6 +62,19 @@ public interface Sardine
 	List<DavResource> list(String url, int depth) throws IOException;
 
 	/**
+	 * Gets a directory listing using WebDAV <code>PROPFIND</code>.
+	 *
+	 * @param url   Path to the resource including protocol and hostname
+	 * @param depth The depth to look at (use 0 for single ressource, 1 for directory listing)
+	 * @param allProp If allprop should be used, which can be inefficient sometimes; 
+	 * warning: no allprop does not retrieve custom props, just the basic ones
+	 * @return List of resources for this URI including the parent resource itself
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	List<DavResource> list(String url, int depth, boolean allProp)
+			throws IOException;
+
+	/**
 	 * @see #patch(String, java.util.Map, java.util.List)
 	 */
 	@Deprecated

--- a/src/de/aflx/sardine/Sardine.java
+++ b/src/de/aflx/sardine/Sardine.java
@@ -3,6 +3,8 @@ package de.aflx.sardine;
 //import javax.xml.namespace.QName;
 import de.aflx.sardine.impl.io.ConsumingInputStream;
 import de.aflx.sardine.util.QName;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -184,6 +186,19 @@ public interface Sardine
 	void put(String url, InputStream dataStream, Map<String, String> headers) throws IOException;
 
 	/**
+	 * Uses <code>PUT</code> to send data to a server with a specific content
+	 * type header. Not repeatable on authentication failure.
+	 *
+	 * @param url		 Path to the resource including protocol and hostname
+	 * @param dataStream  Input source
+	 * @param contentType MIME type to add to the HTTP request header
+	 * @param length length of the stream
+	 * @throws IOException I/O error or HTTP response validation failure
+	 */
+	void put(String url, File dataStream, int length, String contentType)
+			throws IOException;
+
+	/**
 	 * Delete a resource using HTTP <code>DELETE</code> at the specified url
 	 *
 	 * @param url Path to the resource including protocol and hostname
@@ -286,5 +301,6 @@ public interface Sardine
 	 * Disable preemptive authentication.
 	 */
 	void disablePreemptiveAuthentication();
+
 
 }

--- a/src/de/aflx/sardine/impl/SardineImpl.java
+++ b/src/de/aflx/sardine/impl/SardineImpl.java
@@ -101,6 +101,8 @@ import de.aflx.sardine.model.Lockinfo;
 import de.aflx.sardine.model.Lockscope;
 import de.aflx.sardine.model.Locktype;
 import de.aflx.sardine.model.Multistatus;
+import de.aflx.sardine.model.ObjectFactory;
+import de.aflx.sardine.model.Prop;
 import de.aflx.sardine.model.Propfind;
 import de.aflx.sardine.model.Response;
 import de.aflx.sardine.model.Write;
@@ -390,14 +392,25 @@ public class SardineImpl implements Sardine {
 	 * 
 	 * @see de.aflx.sardine.Sardine#list(java.lang.String)
 	 */
-	public List<DavResource> list(String url, int depth) throws IOException {
+	@Override
+	public List<DavResource> list(String url, int depth) throws IOException
+	{
+		return list(url, depth, true);
+	}
+	
+	@Override
+	public List<DavResource> list(String url, int depth, boolean allProp) throws IOException
+	{
 		log.warn("list");
 		HttpPropFind entity = new HttpPropFind(url);
 		entity.setDepth(Integer.toString(depth));
 		Propfind body = new Propfind();
-		body.setAllprop(new Allprop());
+		if (allProp)
+			entity.setEntity(new StringEntity("<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:propfind xmlns:D=\"DAV:\">  <D:allprop/></D:propfind>", UTF_8));
+		else 
+			entity.setEntity(new StringEntity("<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:propfind xmlns:D=\"DAV:\">  <D:prop> <D:creationdate/><D:displayname/><D:resourcetype/><D:getcontentlength/><D:getlastmodified/>  </D:prop></D:propfind>", UTF_8));
+		
 		// entity.setEntity(new StringEntity(SardineUtil.toXml(body), UTF_8));
-		entity.setEntity(new StringEntity("<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:propfind xmlns:D=\"DAV:\">  <D:allprop/></D:propfind>", UTF_8));
 		Multistatus multistatus = this.execute(entity,
 				new MultiStatusResponseHandler());
 		List<Response> responses = multistatus.getResponse();

--- a/src/de/aflx/sardine/impl/SardineImpl.java
+++ b/src/de/aflx/sardine/impl/SardineImpl.java
@@ -866,6 +866,7 @@ public class SardineImpl implements Sardine {
 
 		HttpConnectionParams.setTcpNoDelay(params, true);
 		HttpConnectionParams.setSocketBufferSize(params, 8192);
+		HttpConnectionParams.setConnectionTimeout(params, 10*1000); //10 seconds
 		return params;
 	}
 

--- a/src/de/aflx/sardine/impl/SardineImpl.java
+++ b/src/de/aflx/sardine/impl/SardineImpl.java
@@ -95,15 +95,11 @@ import de.aflx.sardine.impl.methods.HttpMkCol;
 import de.aflx.sardine.impl.methods.HttpMove;
 import de.aflx.sardine.impl.methods.HttpPropFind;
 import de.aflx.sardine.impl.methods.HttpUnlock;
-import de.aflx.sardine.model.Allprop;
 import de.aflx.sardine.model.Exclusive;
 import de.aflx.sardine.model.Lockinfo;
 import de.aflx.sardine.model.Lockscope;
 import de.aflx.sardine.model.Locktype;
 import de.aflx.sardine.model.Multistatus;
-import de.aflx.sardine.model.ObjectFactory;
-import de.aflx.sardine.model.Prop;
-import de.aflx.sardine.model.Propfind;
 import de.aflx.sardine.model.Response;
 import de.aflx.sardine.model.Write;
 import de.aflx.sardine.util.Logger;
@@ -404,7 +400,7 @@ public class SardineImpl implements Sardine {
 		log.warn("list");
 		HttpPropFind entity = new HttpPropFind(url);
 		entity.setDepth(Integer.toString(depth));
-		Propfind body = new Propfind();
+//		Propfind body = new Propfind();
 		if (allProp)
 			entity.setEntity(new StringEntity("<?xml version=\"1.0\" encoding=\"utf-8\" ?><D:propfind xmlns:D=\"DAV:\">  <D:allprop/></D:propfind>", UTF_8));
 		else 

--- a/src/de/aflx/sardine/model/Prop.java
+++ b/src/de/aflx/sardine/model/Prop.java
@@ -57,14 +57,16 @@ public class Prop {
 
 	@Element
 	private Resourcetype resourcetype;
-	@Element
+	@Element (required = false)
 	private String creationdate;
-	@Element
+	@Element (required = false)
 	private String getlastmodified;
-	@Element
+	@Element (required = false)
 	private String getetag;
 	@Element (required = false)
 	private String getcontenttype;
+	@Element (required = false)
+	private String getcontentlength;
 	
 	public Resourcetype getResourcetype() {
 		return resourcetype;
@@ -85,9 +87,17 @@ public class Prop {
 	public String getGetcontenttype() {
 		return getcontenttype;
 	}
-
 	
-    /*protected Creationdate creationdate;
+    public String getGetcontentlength() {
+		return getcontentlength;
+	}
+
+	public void setGetcontentlength(String getcontentlength) {
+		this.getcontentlength = getcontentlength;
+	}
+
+
+	/*protected Creationdate creationdate;
     protected Displayname displayname;
     protected Getcontentlanguage getcontentlanguage;
     protected Getcontentlength getcontentlength;

--- a/src/de/aflx/sardine/model/Prop.java
+++ b/src/de/aflx/sardine/model/Prop.java
@@ -92,10 +92,6 @@ public class Prop {
 		return getcontentlength;
 	}
 
-	public void setGetcontentlength(String getcontentlength) {
-		this.getcontentlength = getcontentlength;
-	}
-
 
 	/*protected Creationdate creationdate;
     protected Displayname displayname;


### PR DESCRIPTION
Allprop can be quite inefficient when the server implements some "magic" auto-props, like the "textcontent" in Milton, which retireves the whole content of text files.

Additionally I implemented getting the file sizes in one request, to be able to show them on the file list in a file manager.
